### PR TITLE
Update .gitignore removing pynecone.db from blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-pynecone.db
+


### PR DESCRIPTION
Removing pynecone.db will result not saving the data to the repository.